### PR TITLE
Added x_deprecated => 1 to metadata, to aid various tools & systems

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 This file documents the revision history for Perl extension MojoX::Redis
 
+0.512 2016-01-16
+        - Added x_deprecated => 1 to metadata, so various tools and systems
+          will automatically ignore this dist
+
 0.511 2012-02-11 00:00:00
         - deprecated
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,8 @@ WriteMakefile(
 
     BUILD_REQUIRES => {'Test::More'  => '0.88'},
     PREREQ_PM      => {'Mojolicious' => '2.37'},
-    META_MERGE =>
-      {resources => {repository => 'https://github.com/und3f/mojox-ping'}},
+    META_MERGE => {
+        x_deprecated => 1,
+        resources => {repository => 'https://github.com/und3f/mojox-ping'},
+    },
 );

--- a/lib/MojoX/Ping.pm
+++ b/lib/MojoX/Ping.pm
@@ -3,7 +3,7 @@ package MojoX::Ping;
 use strict;
 use warnings;
 
-our $VERSION = 0.511;
+our $VERSION = 0.512;
 use base 'Mojo::Base';
 
 use Mojo::IOLoop;


### PR DESCRIPTION
Hi,

This adds the `x_deprecated` field to the metadata files, which will let various tools and systems automatically identify this as a deprecated CPAN distribution.

For example, in the [CPAN Pull Request Challenge](http://cpan-prc.org), I don't assign dists which have this set to true.

Cheers,
Neil
